### PR TITLE
Updates to Version 2.12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'hello-ios-swift' do
-    pod 'LaunchDarkly', '2.11.1'
+    pod 'LaunchDarkly', '2.12.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - DarklyEventSource (3.2.0)
-  - LaunchDarkly (2.11.1):
-    - LaunchDarkly/Core (= 2.11.1)
-  - LaunchDarkly/Core (2.11.1):
-    - DarklyEventSource (~> 3.2.0)
+  - DarklyEventSource (3.2.3)
+  - LaunchDarkly (2.12.0):
+    - LaunchDarkly/Core (= 2.12.0)
+  - LaunchDarkly/Core (2.12.0):
+    - DarklyEventSource (~> 3.2.3)
 
 DEPENDENCIES:
-  - LaunchDarkly (= 2.11.1)
+  - LaunchDarkly (= 2.12.0)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: ad6a75c82b22bea91c75fc980a563f6d2902ce90
-  LaunchDarkly: 830b9e6ee4d8e29162395296fcc176704402445e
+  DarklyEventSource: d5c8e000988ee1feac6c3ffa3dcbdfbaca10d444
+  LaunchDarkly: 5339926c68b711dde38b1689d645b20a56cbbfc2
 
-PODFILE CHECKSUM: c417c788439a5a7542911583307aaeab680ecb22
+PODFILE CHECKSUM: b3bc33b4db0d2472bf540499fcc334dd1c5c98ad
 
 COCOAPODS: 1.4.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - echo "No tests are defined for hello-ios-swift."

--- a/hello-ios-swift/AppDelegate.swift
+++ b/hello-ios-swift/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     // Enter your mobile key here: Account Settings -> Your Projects -> Production/Test -> Mobile key.
-    private let mobileKeyTest = ""
+    private let mobileKey = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         setUpLDClient()
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let userBuilder = LDUserBuilder()
         userBuilder.key = "test@email.com"
 
-        let config = LDConfig(mobileKey: mobileKeyTest)
+        let config = LDConfig(mobileKey: mobileKey)
 
         LDClient.sharedInstance().start(config, with: userBuilder)
     }


### PR DESCRIPTION
also clears circleCI failure due to no tests