### PR TITLE
chore: fix CI to run pod install and properly detect build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           xcode-version: 16.4
 
+      - name: Install CocoaPods dependencies
+        run: pod install
+
       - name: Build hello-ios-swift
-        run: xcodebuild build -workspace 'hello-ios-swift.xcworkspace' -scheme 'hello-ios-swift' CODE_SIGNING_ALLOWED=NO | xcpretty
+        run: set -o pipefail && xcodebuild build -workspace 'hello-ios-swift.xcworkspace' -scheme 'hello-ios-swift' CODE_SIGNING_ALLOWED=NO | xcpretty


### PR DESCRIPTION
## Summary

The CI build has been silently failing because:
1. `pod install` was never run before `xcodebuild`, so the `Pods/Pods.xcodeproj` referenced by the workspace doesn't exist
2. The `| xcpretty` pipe masks `xcodebuild`'s non-zero exit code (bash's default shell in GHA doesn't set `pipefail`)

This adds a `pod install` step before the build and enables `set -o pipefail` so build failures are properly surfaced.

With `pod install` running in CI and the Podfile constraint `>= 9.6.0`, CocoaPods will resolve the latest compatible SDK version (currently 11.2.0). No Podfile or source code changes needed — the code already uses modern `LDContext` APIs.

## How to test
- CI should now run `pod install` and then build successfully with the latest SDK
- If the build fails, the CI step will properly report failure instead of silently passing

Link to Devin session: https://app.devin.ai/sessions/fc319648b4aa4c1d802201170ee6e3f7
Requested by: @kinyoklion