### PR TITLE
chore: update ios-client-sdk from 9.6.0 to 11.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ platform :ios, '13.0'
 use_frameworks!
 
 target 'hello-ios-swift' do
-    pod 'LaunchDarkly', '>= 9.6.0'
+    pod 'LaunchDarkly', '>= 11.2.0'
 end


### PR DESCRIPTION
## Summary

Updates the LaunchDarkly iOS SDK (`LaunchDarkly` pod) minimum version constraint in the Podfile from `>= 9.6.0` to `>= 11.2.0`.

No deprecated APIs were found in the example code — all APIs (`LDContextBuilder`, `LDClient.start(config:context:startWaitSeconds:)`, `LDClient.get()`, `observe(key:owner:handler:)`, `boolVariation(forKey:defaultValue:)`) remain current in 11.x.

Build validation will be performed by CI (requires macOS + Xcode).

Link to Devin session: https://app.devin.ai/sessions/86ba1ba9c7704898b70690616dcd7e1b
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump with no application code changes; main risk is CI/build breakage if 11.x requires a higher iOS/Xcode baseline than the project currently assumes.
> 
> **Overview**
> Raises the **LaunchDarkly** CocoaPods minimum version in the `Podfile` from **`>= 9.6.0`** to **`>= 11.2.0`** for the `hello-ios-swift` target. After `pod install`, builds will resolve the newer iOS client SDK; sample Swift usage is unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b322ac553f05a2202b8dc245d524a60dfeb8d0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->